### PR TITLE
docs(setup): clarify Tavily key + .env setup guidance

### DIFF
--- a/Lab_2/Lab_2.ipynb
+++ b/Lab_2/Lab_2.ipynb
@@ -13,7 +13,24 @@
    "id": "fcd7ea45",
    "metadata": {},
    "source": [
-    "## Setting Up the Environment"
+    "## Setting Up the Environment\n",
+    "\n",
+    "This lab uses [Tavily](https://tavily.com/) as the agent's web-search tool, which requires **your own API key**.\n",
+    "\n",
+    "**Before you run the cells below:**\n",
+    "\n",
+    "1. Create a free Tavily API key at [https://app.tavily.com/home](https://app.tavily.com/home).\n",
+    "2. In the repository root, create a `.env` file by copying the provided template `env.tmp`:\n",
+    "\n",
+    "   ```bash\n",
+    "   cp env.tmp .env\n",
+    "   ```\n",
+    "\n",
+    "3. Open the new `.env` file and paste your key as the value of `TAVILY_API_KEY`.\n",
+    "\n",
+    "The next cell loads these variables from `../.env`.\n",
+    "\n",
+    "> **No Tavily key?** You can use the built-in DuckDuckGo fallback instead: replace `tool = TavilySearch(max_results=4)` with `tool = utils.get_search_tool(max_results=4)` in the cell further down. See the [\"Running without a Tavily key\"](https://github.com/aws-samples/langgraph-agents-with-amazon-bedrock#running-without-a-tavily-key) section of the README."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ cp env.tmp .env
 
 You can edit the preferred region inside `.env` if needed. The default is `us-east-1`, which is one of the supported source regions for the US cross-region inference profiles used by this workshop.
 
+If you are running **locally** and use a named AWS profile (e.g. via `aws configure` or short-term CLI credentials), uncomment the `AWS_PROFILE` line in `.env` and set it to your profile name. Leave it commented out in SageMaker Studio, where credentials are provided by the execution role.
+
 ### 8. Store the Tavily API key
 
 You have two options to store the Tavily API key:

--- a/env.tmp
+++ b/env.tmp
@@ -6,6 +6,13 @@
 # all three (see the README "Models used" section for details).
 AWS_REGION=us-east-1
 
+# Optional: AWS named profile used for credentials when running LOCALLY
+# (e.g. with `aws configure` or short-term CLI credentials). Uncomment and
+# set it to your profile name for local runs. Leave it commented out in
+# SageMaker Studio (or any environment that already provides credentials via an
+# execution role) — it isn't needed there.
+# AWS_PROFILE=<your-aws-profile-name>
+
 # Tavily API key for the agentic-search labs. Free tier is sufficient.
 # Get one at https://app.tavily.com/home
 TAVILY_API_KEY=<paste your api key here>


### PR DESCRIPTION
Address review feedback on the workshop setup flow:

- Lab 2 notebook: expand the 'Setting Up the Environment' markdown cell with explicit, step-by-step guidance to (1) create a Tavily API key, (2) copy env.tmp to .env, and (3) paste the key into TAVILY_API_KEY. Also link to the DuckDuckGo fallback for participants without a key.
- env.tmp: add an optional, commented-out AWS_PROFILE entry with a comment explaining it's only needed for local runs (SageMaker Studio uses the execution role).
- README step 7: add a matching paragraph explaining when to uncomment AWS_PROFILE.